### PR TITLE
Export TSK and set signature creation time on key generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.33"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1828,9 +1828,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.61"
+version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [
  "autocfg 1.0.1",
  "cc",

--- a/openpgp-sdkms/src/lib.rs
+++ b/openpgp-sdkms/src/lib.rs
@@ -704,10 +704,9 @@ impl Decryptor for SdkmsAgent {
         if self.role != Role::Decryptor {
             return Err(Error::msg("bad role for SDKMS agent"));
         }
-        let mut cli = SdkmsClient::builder()
-            .with_api_endpoint(&self.credentials.api_endpoint)
-            .with_api_key(&self.credentials.api_key)
-            .build().expect("could not initialize the SDKMS client");
+
+        let mut cli = self.credentials.http_client()
+            .expect("could not initialize the http client");
 
         match ciphertext {
             mpi::Ciphertext::RSA { c } => {

--- a/openpgp-sdkms/src/lib.rs
+++ b/openpgp-sdkms/src/lib.rs
@@ -960,6 +960,9 @@ fn secret_packet_from_sobject(
     match sobject.obj_type {
         ObjectType::Ec => match sobject.elliptic_curve {
             Some(ApiCurve::Ed25519) => {
+                if raw_secret.len() < 16 {
+                    return Err(anyhow::anyhow!("malformed Ed25519 secret"));
+                }
                 let secret = &raw_secret[16..];
                 match role {
                     KeyRole::Primary => Ok(Key::V4(
@@ -977,6 +980,9 @@ fn secret_packet_from_sobject(
                 }
             }
             Some(ApiCurve::X25519) => {
+                if raw_secret.len() < 16 {
+                    return Err(anyhow::anyhow!("malformed X25519 secret"));
+                }
                 let secret = &raw_secret[16..];
                 match role {
                     KeyRole::Primary => Ok(Key::V4(

--- a/openpgp-sdkms/src/lib.rs
+++ b/openpgp-sdkms/src/lib.rs
@@ -258,6 +258,7 @@ pub fn generate_key(
         .clone()
         .expect("unloaded primary key")
         .into();
+    let prim_creation_time = prim.creation_time();
 
     packets.push(prim.into());
 
@@ -271,6 +272,7 @@ pub fn generate_key(
     let builder = SignatureBuilder::new(SignatureType::PositiveCertification)
         .set_primary_userid(true)?
         .set_key_flags(primary_flags)?
+        .set_signature_creation_time(prim_creation_time)?
         .set_preferred_hash_algorithms(vec![
             HashAlgorithm::SHA512,
             HashAlgorithm::SHA256,
@@ -290,6 +292,7 @@ pub fn generate_key(
         .expect("unloaded subkey")
         .clone()
         .into();
+    let subkey_creation_time = subkey_public.creation_time();
 
     let subkey_flags = KeyFlags::empty()
         .set_storage_encryption()
@@ -297,6 +300,7 @@ pub fn generate_key(
 
     let builder = SignatureBuilder::new(SignatureType::SubkeyBinding)
         .set_hash_algo(HashAlgorithm::SHA512)
+        .set_signature_creation_time(subkey_creation_time)?
         .set_key_flags(subkey_flags)?;
 
     let signature = subkey_public.bind(&mut prim_signer, &cert, builder)?;

--- a/sq/Makefile
+++ b/sq/Makefile
@@ -36,8 +36,13 @@ install: build-release
 	$(MAKE) -C../store install
 
 test-sdkms:
-	./tests/sdkms.sh --p256 -v 0
-	./tests/sdkms.sh --p384 -v 0
-	./tests/sdkms.sh --p521 -v 0
-	./tests/sdkms.sh --rsa3k -v 0
-	./tests/sdkms.sh --cv25519 -v 0
+	./tests/sdkms/extract_sdkms_import_gpg.sh --p256 -v 0
+	./tests/sdkms/extract_sdkms_import_gpg.sh --p384 -v 0
+	./tests/sdkms/extract_sdkms_import_gpg.sh --p521 -v 0
+	# GPG RSA3k issue: ./tests/sdkms/extract_sdkms_import_gpg.sh -v 0
+	./tests/sdkms/extract_sdkms_import_gpg.sh --cv25519 -v 0
+	./tests/sdkms/sq_roundtrips.sh --p256 -v 0
+	./tests/sdkms/sq_roundtrips.sh --p384 -v 0
+	./tests/sdkms/sq_roundtrips.sh --p521 -v 0
+	./tests/sdkms/sq_roundtrips.sh --rsa3k -v 0
+	./tests/sdkms/sq_roundtrips.sh --cv25519 -v 0

--- a/sq/Makefile
+++ b/sq/Makefile
@@ -36,8 +36,8 @@ install: build-release
 	$(MAKE) -C../store install
 
 test-sdkms:
-	./tests/sdkms.sh --p256
-	./tests/sdkms.sh --p384
-	./tests/sdkms.sh --p521
-	./tests/sdkms.sh --rsa3k
-	./tests/sdkms.sh --cv25519
+	./tests/sdkms.sh --p256 -v 0
+	./tests/sdkms.sh --p384 -v 0
+	./tests/sdkms.sh --p521 -v 0
+	./tests/sdkms.sh --rsa3k -v 0
+	./tests/sdkms.sh --cv25519 -v 0

--- a/sq/src/sq-usage.rs
+++ b/sq/src/sq-usage.rs
@@ -359,6 +359,7 @@
 //!     generate                 Generates a new key
 //!     password                 Changes password protecting secrets
 //!     extract-cert             Converts a key to a cert
+//!     extract-sdkms-secret     Extracts a secret key from Fortanix SDKMS
 //!     attest-certifications    Attests to third-party certifications
 //!     adopt                    Binds keys from one certificate to another
 //!     help
@@ -399,6 +400,9 @@
 //!     -h, --help
 //!             Prints help information
 //!
+//!         --sdkms-exportable
+//!             (DANGER) Configure the secret SDKMS key to be exportable in the
+//!             future
 //!     -V, --version
 //!             Prints version information
 //!
@@ -544,6 +548,36 @@
 //!
 //! # Then, this extracts the certificate for distribution
 //! $ sq key extract-cert --output juliet.cert.pgp juliet.key.pgp
+//! ```
+//!
+//! ### Subcommand key extract-sdkms-secret
+//!
+//! ```text
+//! Extracts key from Fortanix SDKMS
+//!
+//! Is a Fortanix SDKMS key was generated using the `--sdkms-exportable` flag, this
+//! command exfiltrates secrets from SDKMS and outputs a Key.
+//!
+//! USAGE:
+//!     sq key extract-sdkms-secret [FLAGS] [OPTIONS] --sdkms-key <SDKMS-KEY-NAME>
+//!
+//! FLAGS:
+//!     -B, --binary
+//!             Emits binary data
+//!
+//!     -h, --help
+//!             Prints help information
+//!
+//!     -V, --version
+//!             Prints version information
+//!
+//!
+//! OPTIONS:
+//!     -o, --output <FILE>
+//!             Writes to FILE or stdout if omitted
+//!
+//!         --sdkms-key <SDKMS-KEY-NAME>
+//!             Name of the SDKMS key
 //! ```
 //!
 //! ### Subcommand key attest-certifications

--- a/sq/src/sq-usage.rs
+++ b/sq/src/sq-usage.rs
@@ -401,8 +401,8 @@
 //!             Prints help information
 //!
 //!         --sdkms-exportable
-//!             (DANGER) Configure the secret SDKMS key to be exportable in the
-//!             future
+//!             (DANGER) Configure the key to be exportable from SDKMS
+//!
 //!     -V, --version
 //!             Prints version information
 //!

--- a/sq/src/sq_cli.rs
+++ b/sq/src/sq_cli.rs
@@ -546,6 +546,10 @@ $ sq key generate --userid \"<juliet@example.org>\" --userid \"Juliet Capulet\"
                         .arg(Arg::with_name("with-password")
                              .long("with-password")
                              .help("Protects the key with a password"))
+                        .arg(Arg::with_name("sdkms-exportable")
+                            .long("sdkms-exportable")
+                            .help("(DANGER) Configure the secret SDKMS key to \
+                                be exportable in the future"))
                         .arg(Arg::with_name("sdkms-key")
                              .long("sdkms-key").value_name("SDKMS-KEY-NAME")
                              .help("Generate secrets inside Fortanix SDKMS with \
@@ -561,10 +565,8 @@ $ sq key generate --userid \"<juliet@example.org>\" --userid \"Juliet Capulet\"
                                  "rev-cert",
                              ])
                              .requires("userid"))
-
                         .group(ArgGroup::with_name("expiration-group")
                                .args(&["expires", "expires-in"]))
-
                         .arg(Arg::with_name("expires")
                              .long("expires").value_name("TIME")
                              .help("Makes the key expire at TIME (as ISO 8601)")
@@ -609,7 +611,6 @@ $ sq key generate --userid \"<juliet@example.org>\" --userid \"Juliet Capulet\"
                         .arg(Arg::with_name("cannot-encrypt")
                              .long("cannot-encrypt")
                              .help("Adds no encryption-capable subkey"))
-
                         .arg(Arg::with_name("export")
                              .short("e").long("export").value_name("OUTFILE")
                              .help("Writes the key to OUTFILE")
@@ -694,6 +695,26 @@ $ sq key extract-cert --output juliet.cert.pgp juliet.key.pgp
                                 .long("sdkms-key").value_name("SDKMS-KEY-NAME")
                                 .help("Extracts the certificate from the Fortanix \
                                  Self-Defending Key-Management System"))
+                            )
+                .subcommand(SubCommand::with_name("extract-sdkms-secret")
+                            .display_order(111)
+                            .about("Extracts a secret key from Fortanix SDKMS")
+                            .long_about(
+"Extracts key from Fortanix SDKMS
+
+Is a Fortanix SDKMS key was generated using the `--sdkms-exportable` flag, this
+command exfiltrates secrets from SDKMS and outputs a Key.
+")
+                            .arg(Arg::with_name("sdkms-key")
+                                .long("sdkms-key").value_name("SDKMS-KEY-NAME")
+                                .required(true)
+                                .help("Name of the SDKMS key"))
+                            .arg(Arg::with_name("output")
+                                 .short("o").long("output").value_name("FILE")
+                                 .help("Writes to FILE or stdout if omitted"))
+                            .arg(Arg::with_name("binary")
+                                 .short("B").long("binary")
+                                 .help("Emits binary data"))
                             )
                 .subcommand(
                     SubCommand::with_name("adopt")
@@ -1119,7 +1140,6 @@ $ sq certify juliet.pgp romeo.pgp \"<romeo@example.org>\"
                               doesn't understand a critical notation, \
                               then it will ignore the signature.  The \
                               notation is marked as being human readable."))
-
                     .group(ArgGroup::with_name("expiration-group")
                            .args(&["expires", "expires-in"]))
                     .arg(Arg::with_name("expires")

--- a/sq/src/sq_cli.rs
+++ b/sq/src/sq_cli.rs
@@ -548,8 +548,7 @@ $ sq key generate --userid \"<juliet@example.org>\" --userid \"Juliet Capulet\"
                              .help("Protects the key with a password"))
                         .arg(Arg::with_name("sdkms-exportable")
                             .long("sdkms-exportable")
-                            .help("(DANGER) Configure the secret SDKMS key to \
-                                be exportable in the future"))
+                            .help("(DANGER) Configure the key to be exportable from SDKMS"))
                         .arg(Arg::with_name("sdkms-key")
                              .long("sdkms-key").value_name("SDKMS-KEY-NAME")
                              .help("Generate secrets inside Fortanix SDKMS with \

--- a/sq/tests/sdkms.sh
+++ b/sq/tests/sdkms.sh
@@ -35,7 +35,7 @@ comm() {
 my_cat() {
     if (( $verbosity == 1 )); then
         head -n4 $1
-        echo "[TRUNCATED]"
+        echo "    [TRUNCATED OUTPUT]"
     fi
     if (( $verbosity == 2 )); then
         cat $1

--- a/sq/tests/sdkms.sh
+++ b/sq/tests/sdkms.sh
@@ -2,6 +2,23 @@
 
 sq="cargo run -- "
 
+# Parse input flags
+case "$1" in
+    --p256) cipher_suite="nistp256";;
+    --p384) cipher_suite="nistp384";;
+    --p521) cipher_suite="nistp521";;
+    --cv25519) cipher_suite="cv25519";;
+    --rsa3k) cipher_suite="rsa3k";;
+    -*) echo "unknown option: $1" >&2; exit 1;;
+esac
+
+if (( $# != 3 )); then
+    echo "Usage: test.sh --[rsa3k, p256, p384, p521, cv25519] -v <int verbosity [0, 1, 2]>"
+    exit 1
+fi
+
+verbosity=$3
+
 # tmp directory, erased on exit
 create_tmp_dir() {
     eval "$1"="$(mktemp -d)"
@@ -15,17 +32,15 @@ comm() {
     printf "$ %s\n" "$1"
 }
 
-# Parse input flags
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --p256) cipher_suite="nistp256"; shift 1;;
-    --p384) cipher_suite="nistp384"; shift 1;;
-    --p521) cipher_suite="nistp521"; shift 1;;
-    --cv25519) cipher_suite="cv25519"; shift 1;;
-    --rsa3k) cipher_suite="rsa3k"; shift 1;;
-    -*) echo "unknown option: $1" >&2; exit 1;;
-  esac
-done
+my_cat() {
+    if (( $verbosity == 1 )); then
+        head -n4 $1
+        echo "[TRUNCATED]"
+    fi
+    if (( $verbosity == 2 )); then
+        cat $1
+    fi
+}
 
 data=""
 create_tmp_dir data
@@ -38,12 +53,15 @@ alice_public=$data/alice.asc
 bob_sdkms=$data/bob_sdkms.asc
 bob_local_priv=$data/bob_local_priv.asc
 bob_local_pub=$data/bob_local_pub.asc
-encrypted=$data/message.txt.gpg
-decrypted=$data/decrypted.txt
+encrypted_nosign=$data/message.txt.encrypted.nosign
+encrypted_signed=$data/message.txt.encrypted.signed
+decrypted_nosign=$data/decrypted.txt.nosign
+decrypted_signed=$data/decrypted.txt.signed
 signed=$data/message.signed.asc
 
-alice_key_name="test-alice-$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "${1:-10}" | head -n 1)"
-bob_key_name="test-bob-bb$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "${1:-10}" | head -n 1)"
+random=$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1)
+alice_key_name="test-alice-$random"
+bob_key_name="test-bob-$random"
 
 comm "version"
 $sq --version
@@ -53,23 +71,39 @@ $sq key generate --sdkms-key="$alice_key_name" --userid="Alice Павловна 
 $sq key generate --sdkms-key="$bob_key_name" --userid="Bob Сергeeвич Прокoфьев <bob@openpgp.example>"
 $sq key generate --userid="Bob Сергeeвич Прокoфьев <bob@openpgp.example>" --export="$bob_local_priv"
 
-comm "certificates"
+comm "certificate Alice"
 $sq key extract-cert --sdkms-key="$alice_key_name" > "$alice_public"
+my_cat "$alice_public"
+comm "certificate Bob SDKMS"
 $sq key extract-cert --sdkms-key="$bob_key_name" > "$bob_sdkms"
+my_cat "$bob_sdkms"
+comm "certificate Bob Local"
 $sq key extract-cert "$bob_local_priv" > "$bob_local_pub"
+my_cat "$bob_local_pub"
 
 printf "Y el verso cae al alma como al pasto el rocío.\n" > "$message"
 
 comm "sign"
 $sq sign --sdkms-key="$alice_key_name" "$message" > "$signed"
+my_cat "$signed"
 
 comm "verify"
 $sq verify --signer-cert="$alice_public" "$signed"
 
-comm "encrypt to Alice, sign with both Bob keys"
-$sq encrypt --signer-sdkms-key="$bob_key_name" --signer-key="$bob_local_priv" --recipient-cert "$alice_public" "$message" --output "$encrypted"
+comm "encrypt to Alice, no signatures"
+$sq encrypt --recipient-cert "$alice_public" "$message" --output "$encrypted_nosign"
+my_cat "$encrypted_nosign"
 
 comm "decrypt"
-$sq decrypt --signer-cert="$bob_sdkms" --signer-cert="$bob_local_pub" --sdkms-key="$alice_key_name" "$encrypted" --output "$decrypted"
+$sq decrypt --sdkms-key="$alice_key_name" "$encrypted_nosign" --output "$decrypted_nosign"
 
-diff "$message" "$decrypted"
+diff "$message" "$decrypted_nosign"
+
+comm "encrypt to Alice, sign with both Bob keys"
+$sq encrypt --signer-sdkms-key="$bob_key_name" --signer-key="$bob_local_priv" --recipient-cert "$alice_public" "$message" --output "$encrypted_signed"
+my_cat "$encrypted_signed"
+
+comm "decrypt"
+$sq decrypt --signer-cert="$bob_sdkms" --signer-cert="$bob_local_pub" --sdkms-key="$alice_key_name" "$encrypted_signed" --output "$decrypted_signed"
+
+diff "$message" "$decrypted_signed"

--- a/sq/tests/sdkms/extract_sdkms_import_gpg.sh
+++ b/sq/tests/sdkms/extract_sdkms_import_gpg.sh
@@ -1,6 +1,13 @@
 #!/bin/bash -e
 
+sq="cargo run --"
+
 # Parse input flags
+if (( $# != 3 )); then
+    echo "Usage: sq_roundtrips.sh [--rsa3k, --p256, -p384, --p521, --cv25519] -v <int verbosity [0, 1, 2]>"
+    exit 1
+fi
+
 case "$1" in
     --p256) cipher_suite="nistp256";;
     --p384) cipher_suite="nistp384";;
@@ -10,12 +17,10 @@ case "$1" in
     -*) echo "unknown option: $1" >&2; exit 1;;
 esac
 
-if (( $# != 3 )); then
-    echo "Usage: extract_sdkms_import_gpg.sh --[rsa3k, p256, p384, p521, cv25519] -v <int verbosity [0, 1, 2]>"
-    exit 1
-fi
-
-verbosity=$3
+case "$3" in
+    0|1|2) verbosity=$3;;
+    *) echo "Select verbosity 0, 1, or 2" >&2; exit 1;;
+esac
 
 # tmp directory, erased on exit
 create_tmp_dir() {
@@ -46,7 +51,6 @@ create_tmp_dir data
 gpg_homedir=""
 create_tmp_dir gpg_homedir
 
-sq="cargo run --"
 gpg="gpg --homedir=$gpg_homedir --trust-model always"
 
 trap 'erase_tmp_dirs' EXIT

--- a/sq/tests/sdkms/extract_sdkms_import_gpg.sh
+++ b/sq/tests/sdkms/extract_sdkms_import_gpg.sh
@@ -1,0 +1,127 @@
+#!/bin/bash -e
+
+# Parse input flags
+case "$1" in
+    --p256) cipher_suite="nistp256";;
+    --p384) cipher_suite="nistp384";;
+    --p521) cipher_suite="nistp521";;
+    --cv25519) cipher_suite="cv25519";;
+    --rsa3k) cipher_suite="rsa3k";;
+    -*) echo "unknown option: $1" >&2; exit 1;;
+esac
+
+if (( $# != 3 )); then
+    echo "Usage: extract_sdkms_import_gpg.sh --[rsa3k, p256, p384, p521, cv25519] -v <int verbosity [0, 1, 2]>"
+    exit 1
+fi
+
+verbosity=$3
+
+# tmp directory, erased on exit
+create_tmp_dir() {
+    eval "$1"="$(mktemp -d)"
+}
+
+erase_tmp_dirs() {
+    rm -rf "$data" "$gpg_homedir"
+}
+
+comm() {
+    printf "~~~ %s ~~~\n" "$1"
+}
+
+my_cat() {
+    if (( $verbosity == 1 )); then
+        head -n4 $1
+        echo "    [TRUNCATED OUTPUT]"
+    fi
+    if (( $verbosity == 2 )); then
+        cat $1
+    fi
+}
+
+data=""
+create_tmp_dir data
+
+gpg_homedir=""
+create_tmp_dir gpg_homedir
+
+sq="cargo run --"
+gpg="gpg --homedir=$gpg_homedir --trust-model always"
+
+trap 'erase_tmp_dirs' EXIT
+
+# Test files
+message=$data/message.txt
+alice_public=$data/alice.asc
+alice_local_priv=$data/alice_local_priv.asc
+bob_public=$data/bob_local_pub.asc
+encrypted=$data/message.txt.gpg
+decrypted_remote=$data/decrypted_remote.txt
+decrypted_local=$data/decrypted_local.txt
+decrypted_gpg=$data/decrypted_gpg.txt
+signed_local=$data/message.signed_local.asc
+signed_remote=$data/message.signed_remote.asc
+signed_gpg=$data/message.signed_gpg.gpg
+
+random=$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1)
+alice_key_name="test-gpg-import-alice-$random"
+bob_key_name="test-gpg-import-bob-$random"
+
+comm "sq --version"
+$sq --version
+comm "gpg --version"
+$gpg --version
+
+comm "generate keys (Alice - exportable with $cipher_suite)"
+$sq key generate --sdkms-key="$alice_key_name" --sdkms-exportable --userid="Alice <alice@openpgp.example>" --cipher-suite="$cipher_suite"
+
+comm "extract Alice key and certificate"
+$sq key extract-sdkms-secret --sdkms-key="$alice_key_name" --output="$alice_local_priv"
+my_cat "$alice_local_priv"
+$sq key extract-cert --sdkms-key="$alice_key_name" --output="$alice_public"
+my_cat "$alice_public"
+
+comm "generate keys (Bob)"
+$sq key generate --sdkms-key="$bob_key_name" --userid="Bob <bob@openpgp.example>"
+$sq key extract-cert --sdkms-key="$bob_key_name" > "$bob_public"
+my_cat "$bob_public"
+
+comm "import keys into gpg"
+$gpg --import "$alice_public"
+$gpg --import "$alice_local_priv"
+$gpg --import "$bob_public"
+
+comm "gpg --list keys; gpg --list-secret-keys"
+$gpg --list-keys
+$gpg --list-secret-keys
+
+printf "Y el verso cae al alma como al pasto el rocío.\n" > "$message"
+
+comm "sign with (i) local key (ii) remote key and (iii) gpg-imported key"
+$sq sign --signer-key="$alice_local_priv" "$message" > "$signed_local"
+my_cat "$signed_local"
+$sq sign --sdkms-key="$alice_key_name" "$message" > "$signed_remote"
+my_cat "$signed_remote"
+$gpg --output=$signed_gpg --sign "$message"
+my_cat "$signed_gpg"
+
+comm "verify with sq and gpg"
+$gpg --verify "$signed_remote"
+$gpg --verify "$signed_local"
+$gpg --verify "$signed_gpg"
+$sq verify --signer-cert="$alice_public" "$signed_remote"
+$sq verify --signer-cert="$alice_public" "$signed_local"
+$sq verify --signer-cert="$alice_public" "$signed_gpg"
+
+comm "encrypt to Alice, sign with Bob's key"
+$sq encrypt --signer-sdkms-key="$bob_key_name" --recipient-cert "$alice_public" "$message" --output "$encrypted"
+my_cat "$encrypted"
+
+comm "decrypt with (i) local key (ii) SDKMS key (iii) gpg-imported key"
+$sq decrypt --signer-cert="$bob_public" --recipient-key="$alice_local_priv" "$encrypted" --output "$decrypted_local"
+diff "$message" "$decrypted_local"
+$sq decrypt --signer-cert="$bob_public" --sdkms-key="$alice_key_name" "$encrypted" --output "$decrypted_remote"
+diff "$message" "$decrypted_remote"
+$gpg --output="$decrypted_gpg" --decrypt "$encrypted"
+diff "$message" "$decrypted_local"

--- a/sq/tests/sdkms/sq_roundtrips.sh
+++ b/sq/tests/sdkms/sq_roundtrips.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-sq="cargo run -- "
+sq="cargo run --"
 
 # Parse input flags
 case "$1" in
@@ -13,7 +13,7 @@ case "$1" in
 esac
 
 if (( $# != 3 )); then
-    echo "Usage: test.sh --[rsa3k, p256, p384, p521, cv25519] -v <int verbosity [0, 1, 2]>"
+    echo "Usage: sq_roundtrips.sh --[rsa3k, p256, p384, p521, cv25519] -v <int verbosity [0, 1, 2]>"
     exit 1
 fi
 
@@ -29,7 +29,7 @@ erase_tmp_dir() {
 }
 
 comm() {
-    printf "$ %s\n" "$1"
+    printf "~~~ %s ~~~\n" "$1"
 }
 
 my_cat() {
@@ -60,8 +60,8 @@ decrypted_signed=$data/decrypted.txt.signed
 signed=$data/message.signed.asc
 
 random=$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1)
-alice_key_name="test-alice-$random"
-bob_key_name="test-bob-$random"
+alice_key_name="test-sq-roundtrip-alice-$random"
+bob_key_name="test-sq-roundtrip-bob-$random"
 
 comm "version"
 $sq --version

--- a/sq/tests/sdkms/sq_roundtrips.sh
+++ b/sq/tests/sdkms/sq_roundtrips.sh
@@ -3,21 +3,24 @@
 sq="cargo run --"
 
 # Parse input flags
+if (( $# != 3 )); then
+    echo "Usage: sq_roundtrips.sh [--rsa3k, --p256, -p384, --p521, --cv25519] -v <int verbosity [0, 1, 2]>"
+    exit 1
+fi
+
 case "$1" in
     --p256) cipher_suite="nistp256";;
     --p384) cipher_suite="nistp384";;
     --p521) cipher_suite="nistp521";;
     --cv25519) cipher_suite="cv25519";;
     --rsa3k) cipher_suite="rsa3k";;
-    -*) echo "unknown option: $1" >&2; exit 1;;
+    *) echo "unknown option: $1" >&2; exit 1;;
 esac
 
-if (( $# != 3 )); then
-    echo "Usage: sq_roundtrips.sh --[rsa3k, p256, p384, p521, cv25519] -v <int verbosity [0, 1, 2]>"
-    exit 1
-fi
-
-verbosity=$3
+case "$3" in
+    0|1|2) verbosity=$3;;
+    *) echo "Select verbosity 0, 1, or 2" >&2; exit 1;;
+esac
 
 # tmp directory, erased on exit
 create_tmp_dir() {


### PR DESCRIPTION
This PR allows to export OpenPGP [Transferable Secret Keys](https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-03#section-11.2), provided that the key was generated with the `--sdkms-exportable` flag. Example:

```
$ sq key generate --sdkms-key="alice" --sdkms-exportable --userid="Alice <alice@openpgp.example>"
$ sq key extract-sdkms-secret --sdkms-key="alice" --output="alice.sec" && head -n 3 alice.sec
-----BEGIN PGP PRIVATE KEY BLOCK-----
Comment: 4BC4 6A5A 53CB E958 CF70  36E9 2DF4 4476 7FCE 9F3E
Comment: Alice <alice@openpgp.example>
``` 

This PR also centralizes the date/time used on binding signatures (clock mismatches can result in e.g. signatures older than keys), and fixes a bug related to the http proxy.