### PR TITLE
Bind keys in SDKMS using KeyLinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,8 +2316,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "sdkms"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c843377a2ed87d63e487c7b41b1a82446ab7dc836addd66d63010ea05b14aaf7"
+source = "git+https://github.com/zugzwang/sdkms-client-rust.git?branch=keylinks#83328a1e8a704d210dbad59771cf85be32d654e8"
 dependencies = [
  "bitflags",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,7 @@ dependencies = [
  "lalrpop",
  "log 0.4.14",
  "sdkms",
+ "semver 1.0.4",
  "sequoia-openpgp",
  "serde",
  "serde_derive",
@@ -2273,7 +2274,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2362,6 +2363,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "semver-parser"

--- a/openpgp-sdkms/Cargo.toml
+++ b/openpgp-sdkms/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4.14"
 spki = "0.4.0"
 sequoia-openpgp = { path = "../openpgp", default-features = false }
 sdkms = { git = "https://github.com/zugzwang/sdkms-client-rust.git", branch = "keylinks" }
+semver = "1.0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/openpgp-sdkms/Cargo.toml
+++ b/openpgp-sdkms/Cargo.toml
@@ -16,7 +16,7 @@ http = "0.2.4"
 log = "0.4.14"
 spki = "0.4.0"
 sequoia-openpgp = { path = "../openpgp", default-features = false }
-sdkms = "0.2.1"
+sdkms = { git = "https://github.com/zugzwang/sdkms-client-rust.git", branch = "keylinks" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/openpgp-sdkms/src/lib.rs
+++ b/openpgp-sdkms/src/lib.rs
@@ -30,7 +30,7 @@ use log::info;
 use sdkms::api_model::Algorithm::Rsa;
 use sdkms::api_model::{
     AgreeKeyMechanism, AgreeKeyRequest, DecryptRequest, DigestAlgorithm,
-    EllipticCurve as ApiCurve, KeyOperations, ObjectType,
+    EllipticCurve as ApiCurve, KeyLinks, KeyOperations, ObjectType,
     RsaEncryptionPaddingPolicy, RsaEncryptionPolicy, RsaOptions,
     RsaSignaturePaddingPolicy, RsaSignaturePolicy, SignRequest, Sobject,
     SobjectDescriptor, SobjectRequest,
@@ -144,28 +144,25 @@ impl SdkmsAgent {
             .get_sobject(None, &descriptor)
             .context(format!("could not get primary key {}", key_name))?;
 
-        if let Some(dict) = sobject.custom_metadata {
-            if dict.contains_key(SDKMS_LABEL_PGP) {
-                let json_str = &dict[SDKMS_LABEL_PGP];
-                let key_md: KeyMetadata = serde_json::from_str(json_str)?;
-                if key_md.subkeys[0].len() == 0 {
-                    return Err(Error::msg("No subkeys found in SDKMS"));
-                }
-                let uid = Uuid::parse_str(&key_md.subkeys[0])?;
-                let descriptor = SobjectDescriptor::Kid(uid);
-                let sobject = http_client
-                    .get_sobject(None, &descriptor)
-                    .context("could not get subkey".to_string())?;
-                let key = PublicKey::from_sobject(sobject, KeyRole::Subkey)?;
-                return Ok(SdkmsAgent {
-                    descriptor,
-                    public: key.sequoia_key.expect("key is not loaded"),
-                    role: Role::Decryptor,
-                    credentials,
-                });
+        if let Some(KeyLinks { subkeys, .. }) = sobject.links {
+            if subkeys.len() == 0 {
+                return Err(Error::msg("No subkeys found in SDKMS"));
             }
+            let uid = subkeys[0];
+            let descriptor = SobjectDescriptor::Kid(uid);
+            let sobject = http_client
+                .get_sobject(None, &descriptor)
+                .context("could not get subkey".to_string())?;
+            let key = PublicKey::from_sobject(sobject, KeyRole::Subkey)?;
+            Ok(SdkmsAgent {
+                descriptor,
+                public: key.sequoia_key.expect("key is not loaded"),
+                role: Role::Decryptor,
+                credentials,
+            })
+        } else {
+            Err(Error::msg("was not able to get decryption subkey"))
         }
-        Err(Error::msg("was not able to get decryption subkey"))
     }
 }
 
@@ -191,7 +188,6 @@ enum KeyRole {
 #[derive(Serialize, Deserialize)]
 struct KeyMetadata {
     certificate: String,
-    subkeys:     Vec<String>,
 }
 
 impl KeyMetadata {
@@ -264,6 +260,18 @@ pub fn generate_key(
         exportable,
     )?;
 
+    info!("bind subkey to primary key in SDKMS");
+    let links = KeyLinks {
+        parent: Some(primary.uid()?),
+        ..Default::default()
+    };
+    let link_update_req = SobjectRequest {
+        links: Some(links),
+        ..Default::default()
+    };
+
+    http_client.update_sobject(&subkey.uid()?, &link_update_req)?;
+
     info!("generate certificate");
     // Primary, UserID + sig, subkey + sig
     let mut packets = Vec::<Packet>::with_capacity(5);
@@ -323,12 +331,11 @@ pub fn generate_key(
     cert = cert
         .insert_packets(vec![Packet::from(subkey_public), signature.into()])?;
 
-    info!("bind keys and store certificate in SDKMS");
+    info!("store certificate in SDKMS");
     let armored = String::from_utf8(cert.armored().to_vec()?)?;
 
     let key_md = KeyMetadata {
         certificate: armored,
-        subkeys:     vec![subkey.uid()?.to_string()],
     };
 
     let key_json = serde_json::to_string(&key_md)?;
@@ -385,17 +392,20 @@ pub fn extract_tsk_from_sdkms(key_name: &str) -> Result<Cert> {
         .export_sobject(&SobjectDescriptor::Name(key_name.to_string()))
         .context(format!("could not export primary secret {}", key_name))?;
     let key_md = KeyMetadata::from_primary_sobject(&prim_sob)?;
-    let packet = secret_packet_from_sobject(prim_sob, KeyRole::Primary)?;
+    let packet = secret_packet_from_sobject(&prim_sob, KeyRole::Primary)?;
     packets.push(packet);
 
     // Subkeys
-    for subkey_name in &key_md.subkeys {
-        let uid = Uuid::parse_str(&subkey_name)?;
-        let sob = http_client
-            .export_sobject(&SobjectDescriptor::Kid(uid))
-            .context(format!("could not export subkey secret {}", key_name))?;
-        let packet = secret_packet_from_sobject(sob, KeyRole::Subkey)?;
-        packets.push(packet);
+    if let Some(KeyLinks { subkeys, .. }) = prim_sob.links {
+        for uid in &subkeys {
+            let sob = http_client
+                .export_sobject(&SobjectDescriptor::Kid(*uid))
+                .context(format!("could not export subkey secret {}", key_name))?;
+            let packet = secret_packet_from_sobject(&sob, KeyRole::Subkey)?;
+            packets.push(packet);
+        }
+    } else {
+        return Err(Error::msg("could not find subkeys"));
     }
 
     // Merge with the known public certificate
@@ -843,13 +853,15 @@ impl Decryptor for SdkmsAgent {
 }
 
 fn secret_packet_from_sobject(
-    sobject: Sobject,
+    sobject: &Sobject,
     role: KeyRole,
 ) -> Result<Packet> {
     let time: SystemTime = sobject.created_at.to_datetime().into();
-    let raw_secret = sobject.value.context("secret bits missing in Sobject")?;
+    let raw_secret = sobject.value.as_ref()
+        .context("secret bits missing in Sobject")?;
     let raw_public =
-        sobject.pub_key.context("public bits missing in Sobject")?;
+        sobject.pub_key.as_ref()
+        .context("public bits missing in Sobject")?;
     let is_signer =
         (sobject.key_ops & KeyOperations::SIGN) == KeyOperations::SIGN;
     match sobject.obj_type {


### PR DESCRIPTION
From 4.2 on, security objects can be linked with key links, without the need to maintain the custom metadata dictionary.

This PR binds the primary key and the subkey using key links.